### PR TITLE
fix d_name_langs

### DIFF
--- a/src/otfm.ml
+++ b/src/otfm.ml
@@ -839,7 +839,7 @@ let lcid_to_bcp47 = [
 
 type lang = string
 
-let rec d_name_langs soff ncount d =
+let d_name_langs soff ncount d =
   d_skip (ncount * 6 * 2) d >>= fun () ->
   d_uint16                d >>= fun lcount ->
   let rec loop i acc =
@@ -852,7 +852,7 @@ let rec d_name_langs soff ncount d =
     seek_pos cpos d >>= fun () ->
     loop (i - 1) ((0x8000 + (ncount - i), lang) :: acc)
   in
-  loop ncount []
+  loop lcount []
 
 let rec d_name_records soff ncount f acc langs seen d =
   if ncount = 0 then Ok acc else


### PR DESCRIPTION
- the function is not recursive

- ncount is the number of name records, and it is used to compute an
  offset where to start reading the LangTagRecord, while lcount is the
  number of items in this table. In addition lcount is unused in the
  function.

I've tried on a single example where unfortunately `ncount = lcount` ;o)