### PR TITLE
fix kern_tables

### DIFF
--- a/src/otfm.ml
+++ b/src/otfm.ml
@@ -1019,14 +1019,14 @@ let rec kern_tables ntables t p acc d =
   | `Skip, acc -> skip acc
   | `Fold, acc ->
       let rec d_pairs len acc d =
-        if len < 3 * 2 then d_skip len d >>= fun () -> Ok acc else
+        if len <= 0 then d_skip len d >>= fun () -> Ok acc else
         d_uint16 d >>= fun left ->
         d_uint16 d >>= fun right ->
         d_int16 d >>= fun values ->
         d_pairs (len - 3 * 2) (p acc left right values) d
       in
       d_skip (4 * 2)  d >>= fun () ->
-      d_pairs len acc d >>= fun acc ->
+      d_pairs (len - 4 * 2 - 3 * 2) acc d >>= fun acc ->
       kern_tables (ntables - 1) t p acc d
 
 let kern d t p acc =


### PR DESCRIPTION
The variable [len] read at the beginning of a table corresponds to the
full length of the table, header included. The Microsoft spec [0]
says:

> Type		Field	Description
> uint16	length	Length of the subtable, in bytes (including this header).

So when reading the pairs, the number of bytes to be read is len minus
3 uint16 (version, length, coverage) and minus the 4 uint16 that are
skipped just before the pairs.

I also modified the termination condition accordingly so that it's
clearer we stop when all bytes are read.

[0] https://docs.microsoft.com/en-us/typography/opentype/spec/kern