### PR TITLE
opam: fixed version constraint on ocaml

### DIFF
--- a/opam
+++ b/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/otfm/issues"
 tags: [ "OpenType" "ttf" "font" "decoder" "graphics" "org:erratique" ]
 license: "ISC"
 depends: [
- "ocaml-version" {>= "4.05.0"}
+ "ocaml" {>= "4.05.0"}
  "ocamlfind" {build}
  "ocamlbuild" {build}
  "topkg" {build}


### PR DESCRIPTION
The constraint on compiler version introduced in c2b0236 seems incorrect, at least it is interpreted by opam as a constraint on the `ocaml-version` **package**. Which leads to the following complaint:
```sh
$opam pin add otfm --dev-repo
[otfm.0.3.0] synchronised from git+http://erratique.ch/repos/otfm.git
[WARNING] Failed checks on otfm package definition from source at git+http://erratique.ch/repos/otfm.git:
    error 57: Synopsis and description must not be both empty
otfm is now pinned to git+http://erratique.ch/repos/otfm.git (version 0.3.0)

The following dependencies couldn't be met:
  - otfm → ocaml-version >= 4.05.0
      no matching version

[NOTE] Pinning command successful, but your installed packages may be out of sync.
```